### PR TITLE
Fix bug unable to create GCP image with guest packages

### DIFF
--- a/meilisearch.pkr.hcl
+++ b/meilisearch.pkr.hcl
@@ -88,19 +88,18 @@ source "digitalocean" "debian" {
 }
 
 source "googlecompute" "debian" {
-  image_name   = lower(replace("${var.image_name}-${var.meilisearch_version}-${var.base-os-version}", ".", "-"))
-  project_id   = "meilisearchimage"
-  source_image = "debian-11-bullseye-v20230411"
-  ssh_username = "packer"
-  machine_type = "e2-small"
-  zone         = "us-central1-a"
+  image_name          = lower(replace("${var.image_name}-${var.meilisearch_version}-${var.base-os-version}", ".", "-"))
+  project_id          = "meilisearchimage"
+  source_image_family = "debian-11"
+  ssh_username        = "packer"
+  zone                = "us-central1-a"
 }
 
 build {
   sources = [
     "source.amazon-ebs.debian",
     "source.digitalocean.debian",
-    "sources.googlecompute.debian"
+    "source.googlecompute.debian"
   ]
 
   provisioner "file" {
@@ -165,5 +164,14 @@ build {
       "curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/99-img-check.sh | bash",
     ]
     only = ["digitalocean.debian"]
+  }
+
+  // This prevents image creation failure when Install guest packages is checked.
+  provisioner "shell" {
+    execute_command = "echo 'packer' | sudo -S sh -c '{{ .Vars }} {{ .Path }}'"
+    inline = [
+      "sudo apt-get remove google-cloud-cli -y",
+    ]
+    only = ["googlecompute.debian"]
   }
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #56

## What does this PR do?
- This PR removes the `google-cloud-cli` when building an image. This prevents image creation failure when `Install guest packages` is checked.
