### PR TITLE
Add DIGITALOCEAN_ACCESS_TOKEN to manual publish

### DIFF
--- a/.github/workflows/manual_publish.yml
+++ b/.github/workflows/manual_publish.yml
@@ -16,6 +16,7 @@ env:
   PACKER_VERSION: "latest"
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
 jobs:
   publishing:


### PR DESCRIPTION
For some reason the token was not there thus the manual publish for DO didn't work