### PR TITLE
Add ca-west-1 to AWS Regions

### DIFF
--- a/meilisearch.pkr.hcl
+++ b/meilisearch.pkr.hcl
@@ -44,6 +44,7 @@ source "amazon-ebs" "debian" {
     "ap-southeast-1",
     "ap-southeast-2",
     "ca-central-1",
+    "ca-west-1",
     "eu-central-1",
     "eu-north-1",
     "eu-south-1",


### PR DESCRIPTION
# Pull Request

## Related issue

https://discord.com/channels/1006923006964154428/1254136618751885392

## What does this PR do?

Allows the AMI to be used by EC2 instances in Cowtown.

## PR checklist

Please check if your PR fulfills the following requirements:

- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
