### PR TITLE
Replace hard coded db-path with value at MEILI_DB_PATH passed by user.

### DIFF
--- a/scripts/first-login/001-setup-prod.sh
+++ b/scripts/first-login/001-setup-prod.sh
@@ -40,7 +40,8 @@ After=systemd-user-sessions.service
 Type=simple
 Environment="MEILI_SERVER_PROVIDER=$MEILISEARCH_SERVER_PROVIDER"
 Environment="MEILI_DUMP_DIR=$MEILI_DUMP_DIR"
-ExecStart=/usr/bin/meilisearch --db-path /var/lib/meilisearch/data.ms --env $MEILISEARCH_ENVIRONMENT --dump-dir $MEILI_DUMP_DIR
+Environment="MEILI_DB_PATH=$MEILI_DB_PATH"
+ExecStart=/usr/bin/meilisearch --db-path $MEILI_DB_PATH --env $MEILISEARCH_ENVIRONMENT --dump-dir $MEILI_DUMP_DIR
 
 [Install]
 WantedBy=default.target
@@ -60,7 +61,8 @@ Type=simple
 Environment="MEILI_MASTER_KEY=$MEILISEARCH_MASTER_KEY"
 Environment="MEILI_SERVER_PROVIDER=$MEILISEARCH_SERVER_PROVIDER"
 Environment="MEILI_DUMP_DIR=$MEILI_DUMP_DIR"
-ExecStart=/usr/bin/meilisearch --db-path /var/lib/meilisearch/data.ms --env $MEILISEARCH_ENVIRONMENT --dump-dir $MEILI_DUMP_DIR
+Environment="MEILI_DB_PATH=$MEILI_DB_PATH"
+ExecStart=/usr/bin/meilisearch --db-path $MEILI_DB_PATH --env $MEILISEARCH_ENVIRONMENT --dump-dir $MEILI_DUMP_DIR
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #87 

## What does this PR do?
- Updates first-login/001-setup-prod.sh to use MEILI_DB_PATH rather than hardcoded db-path to prevent meilisearch-setup from overwriting user specified DB_PATH.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ x ] Have you read the contributing guidelines?
- [ x ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
